### PR TITLE
Handle case where node id has no associated elements list

### DIFF
--- a/src/findTags.js
+++ b/src/findTags.js
@@ -42,9 +42,11 @@ export default function findTags(filename, source) {
       } else {
         // for array desctructuring
         let elements = node.id.elements;
-        for (let i = 0; i < elements.length; i++) {
-          let el = elements[i];
-          collect({ tagname: el.name, filename: filename, loc: el.loc, type: 'v' }, node);
+        if (elements && elements.length) {
+          for (let i = 0; i < elements.length; i++) {
+            let el = elements[i];
+            collect({ tagname: el.name, filename: filename, loc: el.loc, type: 'v' }, node);
+          }
         }
       }
     },


### PR DESCRIPTION
Certain variable declarators will not have an elements list associated with the node id, in which case attempting to access the `length` property on line 45 will fail
